### PR TITLE
Include XCrypt.dll for build purposes

### DIFF
--- a/DBViewer/DBViewer/DBS2QVLS.csproj
+++ b/DBViewer/DBViewer/DBS2QVLS.csproj
@@ -150,6 +150,9 @@
     <Content Include="Options.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="XCrypt.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="bin\" />


### PR DESCRIPTION
Include XCrypt.dll so the project will build correctly.